### PR TITLE
handlebars now display post title

### DIFF
--- a/assets/scripts/templates/blogs-listing.handlebars
+++ b/assets/scripts/templates/blogs-listing.handlebars
@@ -3,7 +3,9 @@
 <div id="all-blogs-container" class="col-xs-4 box">
     <div id="all-blogs-container" data-id="{{blog.id}}">
       <ul name='blog-name' class='handlebars-fields'>Title: <span class='handlebars' id='blog-title'>{{blog.title}}</span></ul>
-      <ul name='blog-posts' class='handlebars-fields'>Posts: <span class='handlebars' id='blog-posts'>{{blog.posts}}</span></ul>
+      {{#posts}}
+      <ul name='blog-posts' class='handlebars-fields'>Posts: <span class='handlebars' id='blog-posts'>{{title}}</span></ul>
+      {{/posts}}
       <input type='text' id="blog-id" name= 'blod-id' value= "{{blog.id}}">
 
 


### PR DESCRIPTION
modified view all blogs handlebars to also display the title of each
post nested under each blog. If a blog has no posts, then 'title' is not
shown.